### PR TITLE
Remove broken videos from 2009 conf

### DIFF
--- a/_posts/2009-02-20-code4lib-2009-lightning-talks.md
+++ b/_posts/2009-02-20-code4lib-2009-lightning-talks.md
@@ -34,7 +34,7 @@ See <a href="/conference/2008/lightning">2008 Lightning Talks</a>.
 
 <p><a href="mailto:roytennant@gmail.com">Email Roy Tennant</a> with presentation files and/or corrections to this page.</p>
 
-<h2>Tuesday, February 24, <a href="http://dl.lib.brown.edu/code4lib/lightning_day1.html" target="_blank">[QuickTime Video]</a>  <a href="http://www.archive.org/details/Code4lib2009LightningTalksDayOne" target="_blank">[Internet Archive Video]</a></h2>
+<h2>Tuesday, February 24, <a href="http://www.archive.org/details/Code4lib2009LightningTalksDayOne" target="_blank">[Internet Archive Video]</a></h2>
 
 <ol>
 <li>The eXtensible Catalog Project [<a href="/files/XC_Lightning.ppt">Slides in PPT</a>], David Lindahl</li>
@@ -56,7 +56,7 @@ See <a href="/conference/2008/lightning">2008 Lightning Talks</a>.
 </ol>
 
 
-<h2>Wednesday, February 25, <a href="http://dl.lib.brown.edu/code4lib/lightning_day2.html" target="_blank">[QuickTime Video]</a>  <a href="http://www.archive.org/details/Code4lib2009LightningTalksDayTwo" target="_blank">[Internet Archive Video]</a></h2>
+<h2>Wednesday, February 25, <a href="http://www.archive.org/details/Code4lib2009LightningTalksDayTwo" target="_blank">[Internet Archive Video]</a></h2>
 <ol>
 <li>Build A Connector Online Now : the Connector Framework Firefox extension / Mike Taylor (IndexData)</li>
 <li>Code4Lib Annual Award for Some Sort of Good Software (that should probably be open source) / Eric Lease Morgan</li>
@@ -76,7 +76,7 @@ See <a href="/conference/2008/lightning">2008 Lightning Talks</a>.
 <li>SALT Project / Chris Fitzpatrick (Stanford University)</li>
 </ol>
 
-<h2>Thursday, February 26, <a href="http://dl.lib.brown.edu/code4lib/lightning_day3.html" target="_blank">[QuickTime Video]</a>  <a href="http://www.archive.org/details/Code4lib2009LightningTalksDayThree" target="_blank">[Internet Archive Video]</a></h2>
+<h2>Thursday, February 26, <a href="http://www.archive.org/details/Code4lib2009LightningTalksDayThree" target="_blank">[Internet Archive Video]</a></h2>
 
 <ol>
 <li>bookgenius.org / Chris Morgan</li>

--- a/_posts/2009-05-01-why-libraries-should-embrace-linked-data.md
+++ b/_posts/2009-05-01-why-libraries-should-embrace-linked-data.md
@@ -17,10 +17,6 @@ permalink: /conference/2009/soderback/
 <strong>Anders Söderbäck</strong>, National Library of Sweden
 
 The promise of Linked Data is not that it is another way of aggregating data. For too long have library data been trapped within data-silos only accessible through obscure protocols. Why is access to library data still an issue? Letting everyone access and link to library data lets anyone build the next killer app. LIBRIS, the Swedish Union Catalogue is, since the beginning of this year, available as Linked Data. We discuss how and why.
-<p>&nbsp;</p>
-<strong>QuickTime Video:</strong>
-<a href="http://dl.lib.brown.edu/code4lib/soderback.html" target="_blank">
-<img src="http://code4lib.org/files/02_soderback.jpg" border="0" width="320" height="213"></a>
 
 <p>&nbsp;</p>
 
@@ -31,7 +27,3 @@ The promise of Linked Data is not that it is another way of aggregating data. Fo
 <strong>Presentation:</strong>
 <a href="http://code4lib.org/files/LIBRIS_code4lib.pdf" target="_blank">Slides in PDF</a>
 <a href="http://www.slideshare.net/eby/why-libraries-should-embrace-linked-data" target="_blank">Slides in Slideshare</a>
-
-
-
-

--- a/_posts/2009-05-08-a-bookless-future-for-libraries-a-comedy-in-3-acts.md
+++ b/_posts/2009-05-08-a-bookless-future-for-libraries-a-comedy-in-3-acts.md
@@ -1,10 +1,5 @@
 ---
-excerpt: "<strong>Stefano Mazzocchi</strong>\r\nKeynote Address\r\n\r\n<p>&nbsp;</p>\r\n<strong>QuickTime
-  Video:</strong>\r\n[Footage of the speaker was inadvertently not captured.]\r\n<a
-  href=\"http://dl.lib.brown.edu/code4lib/mazzocchi.html\" target=\"_blank\">\r\n<img
-  src=\"http://dl.lib.brown.edu/code4lib//01_mazzocchi.jpg\" border=\"0\" width=\"320\"
-  height=\"213\"></a>\r\n\r\n<p>&nbsp;</p>\r\n\r\n<a href=\"http://www.archive.org/details/Code4lib2009KeynoteAddressStefanoMazzocchi\">Video
-  on Internet Archive</a>\r\n\r\n<p>&nbsp;</p>"
+excerpt: "<strong>Stefano Mazzocchi</strong>\r\nKeynote Address"
 categories:
 - conferences
 - code4lib 2009
@@ -17,12 +12,8 @@ permalink: /conference/2009/mazzocchi/
 Keynote Address
 
 <p>&nbsp;</p>
-<strong>QuickTime Video:</strong>
-[Footage of the speaker was inadvertently not captured.]
-<a href="http://dl.lib.brown.edu/code4lib/mazzocchi.html" target="_blank">
-<img src="http://dl.lib.brown.edu/code4lib//01_mazzocchi.jpg" border="0" width="320" height="213"></a>
 
-<p>&nbsp;</p>
+[Footage of the speaker was inadvertently not captured.]
 
 <a href="http://www.archive.org/details/Code4lib2009KeynoteAddressStefanoMazzocchi">Video on Internet Archive</a>
 
@@ -30,8 +21,3 @@ Keynote Address
 
 <strong>Presentation:</strong>
 <a href="http://www.betaversion.org/~stefano/papers/code4lib2009.pdf" target="_blank">Slides in PDF</a>
-
-
-
-
-

--- a/_posts/2009-05-08-djatoka-for-djummies.md
+++ b/_posts/2009-05-08-djatoka-for-djummies.md
@@ -19,11 +19,6 @@ permalink: /conference/2009/clarke/
 What kind of dummy would volunteer to do a presentation on a product he hasn't even tried before? Perhaps the kind that has three weeks off from work in Dec./Jan. Or, perhaps the kind that hopes others will join him in this radical experiment. I'm very interested in learning more about djatoka so propose to share what I learn over the next two months in a twenty minute presentation.
 
 <p>&nbsp;</p>
-<strong>QuickTime Video:</strong>
-<a href="http://dl.lib.brown.edu/code4lib/clarke.html" target="_blank">
-<img src="http://dl.lib.brown.edu/code4lib//10_clarke.jpg" border="0" width="320" height="213"></a>
-
-<p>&nbsp;</p>
 
 <a href="http://www.archive.org/details/Code4lib2009DjatokaForDjummies">Video on Internet Archive</a>
 
@@ -32,7 +27,3 @@ What kind of dummy would volunteer to do a presentation on a product he hasn't e
 <strong>Presentation:</strong>
 <a href="http://code4lib.org/files/djatoka.pdf" target="_blank">Slides in PDF</a>
 <a href="http://www.slideshare.net/eby/djatoka-for-djummies" target="_blank">Slides in Slideshare</a>
-
-
-
-

--- a/_posts/2009-05-08-how-i-failed-to-present-on-using-dvcs-for-managing-archival-metadata.md
+++ b/_posts/2009-05-08-how-i-failed-to-present-on-using-dvcs-for-managing-archival-metadata.md
@@ -20,11 +20,6 @@ Mark A. Matienzo</strong>, The New York Public Library
 Building on Galen Charlton's investigations into distributed version control systems for metadata management, I was going to offer a prototype system for managing archival finding aids in EAD (Encoded Archival Description). My prototype relied on distributed version control and uses post-commit hooks to initiate indexing and publishing processes. However, I ran into some serious barriers in my implementation, and my talk will focus on the fundamental problem of algorithmically diffing and expressing patches for XML documents
 
 <p>&nbsp;</p>
-<strong>QuickTime Video:</strong>
-<a href="http://dl.lib.brown.edu/code4lib/matienzo.html" target="_blank">
-<img src="http://dl.lib.brown.edu/code4lib//08_matienzo.jpg" border="0" width="320" height="213"></a>
-
-<p>&nbsp;</p>
 
 <a href="http://www.archive.org/details/Code4lib2009HowIFailedToPresentOnUsingDvcsForManagingArchival">Video on Internet Archive</a>
 
@@ -32,7 +27,3 @@ Building on Galen Charlton's investigations into distributed version control sys
 
 <strong>Presentation:</strong>
 <a href="http://www.slideshare.net/anarchivist/how-i-failed-to-present-on-using-dvcs-to-control-archival-metadata" target="_blank">Slides on Slideshare</a>
-
-
-
-

--- a/_posts/2009-05-08-libx-2-0.md
+++ b/_posts/2009-05-08-libx-2-0.md
@@ -19,11 +19,6 @@ permalink: /conference/2009/back/
 Since its inception, the LibX browser plugin has been adopted by over 500 libraries to provide access to their services at the user's point of need. We are now developing LibX 2.0, a community platform that allows anybody to create, share, and deploy library services in a distributed and decentralized fashion. We'll describe the technology used in LibX 2.0, with a particular emphasis on the developer API and the deployment infrastructure facilitating this community engagement.
 
 <p>&nbsp;</p>
-<strong>QuickTime Video:</strong>
-<a href="http://dl.lib.brown.edu/code4lib/back.html" target="_blank">
-<img src="http://dl.lib.brown.edu/code4lib//09_back.jpg" border="0" width="320" height="213"></a>
-
-<p>&nbsp;</p>
 
 <a href="http://www.archive.org/details/Code4lib2009Libx2.0">Video on Internet Archive</a>
 
@@ -32,7 +27,3 @@ Since its inception, the LibX browser plugin has been adopted by over 500 librar
 <strong>Presentation:</strong>
 Slides in <a href="/files/LibX2.0-Code4Lib-2009AsPresented.pdf">PDF</a> and <a href="/files/LibX2.0-Code4Lib-2009AsPresented.ppt">PPT</a>
 <a href="http://www.slideshare.net/eby/libx-20" target="_blank">Slides in Slideshare</a>
-
-
-
-

--- a/_posts/2009-05-08-like-a-can-opener-for-your-data-silo-simple-access-through-atompub-and-jangle.md
+++ b/_posts/2009-05-08-like-a-can-opener-for-your-data-silo-simple-access-through-atompub-and-jangle.md
@@ -18,11 +18,6 @@ permalink: /conference/2009/singer/
 Jangle is an open specification to apply the Atom Publishing Protocol (AtomPub) to library systems and data. It provides a simple RESTful interface that can be accessed with common Atom Syndication and AtomPub clients making it easier to integrate library data into other applications. This presentation will describe the architecture of Jangle, show how it works and give some ideas as to how it could be used for common integration problems.
 
 <p>&nbsp;</p>
-<strong>QuickTime Video:</strong>
-<a href="http://dl.lib.brown.edu/code4lib/singer.html" target="_blank">
-<img src="http://dl.lib.brown.edu/code4lib//03_singer.jpg" border="0" width="320" height="213"></a>
-
-<p>&nbsp;</p>
 
 <a href="http://www.archive.org/details/Code4lib2009LikeACanOpenerForYourDataSiloSimpleAccessThrough">Video on Internet Archive</a>
 
@@ -31,7 +26,3 @@ Jangle is an open specification to apply the Atom Publishing Protocol (AtomPub) 
 <strong>Presentation:</strong>
 <a href="http://code4lib.org/files/jangle4lib.pdf" target="_blank">Slides in PDF</a>
 <a href="http://www.slideshare.net/eby/like-a-can-opener-for-your-data-silo-simple-access-through-atompub-and-jangle" target="_blank">Slides in Slideshare</a>
-
-
-
-

--- a/_posts/2009-05-08-lusql-quickly-and-easily-getting-your-data-from-your-dbms-into-lucene.md
+++ b/_posts/2009-05-08-lusql-quickly-and-easily-getting-your-data-from-your-dbms-into-lucene.md
@@ -18,11 +18,6 @@ permalink: /conference/2009/newton/
 Need to move your data from your DBMS to Lucene? The recently released LuSql allows you to do this in a single line. LuSql is a high performance, low use barrier application for getting DBMS data into Lucene. This presentation will introduce LuSql, and give a brief tutorial on simple to crazy complicated use cases, including per document sub-queries and out-of-band document transformations.
 
 <p>&nbsp;</p>
-<strong>QuickTime Video:</strong>
-<a href="http://dl.lib.brown.edu/code4lib/newton.html" target="_blank">
-<img src="http://dl.lib.brown.edu/code4lib//04_newton.jpg" border="0" width="320" height="213"></a>
-
-<p>&nbsp;</p>
 
 <a href="http://www.archive.org/details/Code4lib2009LusqlquicklyAndEasilyGettingYourDataFromYourDbms">Video on Internet Archive</a>
 
@@ -31,7 +26,3 @@ Need to move your data from your DBMS to Lucene? The recently released LuSql all
 <strong>Presentation:</strong>
 <a href="http://code4lib.org/files/glen_newton_LuSql.pdf" target="_blank">Slides in PDF</a>
 <a href="http://www.slideshare.net/eby/lusql-quickly-and-easily-getting-your-data-from-your-dbms-into-lucene" target="_blank">Slides in Slideshare</a>
-
-
-
-

--- a/_posts/2009-05-08-open-up-your-repository-with-a-sword.md
+++ b/_posts/2009-05-08-open-up-your-repository-with-a-sword.md
@@ -18,11 +18,6 @@ permalink: /conference/2009/summers/
 Simple Web Service Offering Repository Deposit (SWORD) is a lightweight protocol for depositing repository objects over HTTP, developed by the JISC. SWORD is a profile of the Atom Publishing Protocol (RFC 5023), geared to the digital library community. This presentation will discuss the SWORD specification, highlighting how it could be used to provide a deposit API for your repository infrastructure.
 
 <p>&nbsp;</p>
-<strong>QuickTime Video:</strong>
-<a href="http://dl.lib.brown.edu/code4lib/summers.html" target="_blank">
-<img src="http://dl.lib.brown.edu/code4lib//07_summers.jpg" border="0" width="320" height="213"></a>
-
-<p>&nbsp;</p>
 
 <a href="http://www.archive.org/details/Code4lib2009OpenUpYourRepositoryWithASword">Video on Internet Archive</a>
 
@@ -31,7 +26,3 @@ Simple Web Service Offering Repository Deposit (SWORD) is a lightweight protocol
 <strong>Presentation:</strong>
 <a href="http://code4lib.org/files/Open_Up_Your_RepositoryWith_a_SWORD_.pdf" target="_blank">Slides in PDF</a>
 <a href="http://docs.google.com/Presentation?docid=dv89m3d_3hfbjmbhq" target="_blank">Slides on Google Docs</a>
-
-
-
-

--- a/_posts/2009-05-08-restafarian-ism-at-the-nla.md
+++ b/_posts/2009-05-08-restafarian-ism-at-the-nla.md
@@ -18,11 +18,6 @@ permalink: /conference/2009/ingram/
 Two years ago the National Library of Australia decided to go the route of SOA, particularly REST web services. Since then we have developed a stack of them for varying projects. This talk will expose a few of those services (that provide MARCXML, MODS, METS, Identity information and Copyright Status), highlight some of the technology choices and give some idea of the success of this approach.
 
 <p>&nbsp;</p>
-<strong>QuickTime Video:</strong>
-<a href="http://dl.lib.brown.edu/code4lib/ingram.html" target="_blank">
-<img src="http://dl.lib.brown.edu/code4lib//05_ingram.jpg" border="0" width="320" height="213"></a>
-
-<p>&nbsp;</p>
 
 <a href="http://www.archive.org/details/Code4lib2009Restafarian-ismAtTheNla">Video on Internet Archive</a>
 
@@ -31,7 +26,3 @@ Two years ago the National Library of Australia decided to go the route of SOA, 
 <strong>Presentation:</strong>
 <a href="http://code4lib.org/files/TerenceIngram.pdf" target="_blank">Slides in PDF</a>
 <a href="http://www.slideshare.net/eby/restafarianism-at-the-nla" target="_blank">Slides in Slideshare</a>
-
-
-
-

--- a/_posts/2009-05-08-the-dashboard-initiative.md
+++ b/_posts/2009-05-08-the-dashboard-initiative.md
@@ -19,11 +19,6 @@ permalink: /conference/2009/diana/
 How to monitor, in near-real-time, usage of all the great services we build and offer? Often stats-production isn't built-in to our services, and when it is, the lack of standard output makes centralized monitoring difficult. Brown's Library is experimenting with a valued corporate solution, building standardized stats output and trend visualization for new and existing projects -- and centrally exposing this info. This talk will cover our dashboard/widget implementation.
 
 <p>&nbsp;</p>
-<strong>QuickTime Video:</strong>
-<a href="http://dl.lib.brown.edu/code4lib/diana.html" target="_blank">
-<img src="http://dl.lib.brown.edu/code4lib//06_diana.jpg" border="0" width="320" height="213"></a>
-
-<p>&nbsp;</p>
 
 <a href="http://www.archive.org/details/Code4lib2009TheDashboardInitiative">Video on Internet Archive</a>
 
@@ -31,7 +26,3 @@ How to monitor, in near-real-time, usage of all the great services we build and 
 
 <strong>Presentation:</a>
 <a href="http://library.brown.edu/django_media/dashboard/files/dashboard_c4l09.pdf">Slides in PDF</a>
-
-
-
-

--- a/_posts/2009-05-13-a-new-frontier-the-open-library-environment-ole.md
+++ b/_posts/2009-05-13-a-new-frontier-the-open-library-environment-ole.md
@@ -17,11 +17,6 @@ permalink: /conference/2009/mcgeary/
 This presentation will be a progress update on the design of the Open Library Environment. At the time of the conference, business process modeling workshops will have been completed, thus allowing for presenting how the service-oriented architecture is taking shape. There will also be details on how to participate in the project.
 
 <p>&nbsp;</p>
-<strong>QuickTime Video:</strong>
-<a href="http://dl.lib.brown.edu/code4lib/mcgeary.html" target="_blank">
-<img src="http://dl.lib.brown.edu/code4lib//13_mcgeary.jpg" border="0" width="320" height="213"></a>
-
-<p>&nbsp;</p>
 
 <a href="http://www.archive.org/details/Code4lib2009ANewFrontier-TheOpenLibraryEnvironmentole">Video on Internet Archive</a>
 
@@ -29,7 +24,3 @@ This presentation will be a progress update on the design of the Open Library En
 
 <strong>Presentation:</strong>
 <a href="http://code4lib.org/files/TMcGeary_code4lib09.pdf" target="_blank">Slides in PDF</a>
-
-
-
-

--- a/_posts/2009-05-13-blacklight-as-a-unified-discovery-platform.md
+++ b/_posts/2009-05-13-blacklight-as-a-unified-discovery-platform.md
@@ -17,11 +17,6 @@ permalink: /conference/2009/sadler/
 At UVA, Blacklight is more than an open source OPAC; it also provides a unified discovery framework for items from our institutional repository, our art museum, and our geospatial data repository, and each kind of object has appropriate specific behaviors. This talk will discuss how we put this together, and how you can too.
 
 <p>&nbsp;</p>
-<strong>QuickTime Video:</strong>
-<a href="http://dl.lib.brown.edu/code4lib/sadler.html" target="_blank">
-<img src="http://dl.lib.brown.edu/code4lib//14_sadler.jpg" border="0" width="320" height="213"></a>
-
-<p>&nbsp;</p>
 
 <a href="http://www.archive.org/details/Code4lib2009BlacklightAsAUnifiedDiscoveryPlatform">Video on Internet Archive</a>
 
@@ -29,8 +24,3 @@ At UVA, Blacklight is more than an open source OPAC; it also provides a unified 
 
 <strong>Presentation:</strong>
 <a href="http://code4lib.org/files/blacklight_code4lib09.pdf" target="_blank">Slides in PDF</a>
-
-
-
-
-

--- a/_posts/2009-05-13-sebastian-hammer-keynote-address.md
+++ b/_posts/2009-05-13-sebastian-hammer-keynote-address.md
@@ -11,11 +11,6 @@ permalink: /conference/2009/hammer/
 Keynote Address
 
 <p>&nbsp;</p>
-<strong>QuickTime Video:</strong>
-<a href="http://dl.lib.brown.edu/code4lib/hammer.html" target="_blank">
-<img src="http://dl.lib.brown.edu/code4lib//12_hammer.jpg" border="0" width="320" height="213"></a>
-
-<p>&nbsp;</p>
 
 <a href="http://www.archive.org/details/Code4lib2009KeynoteAddressSebastianHammer">Video on Internet Archive</a>
 
@@ -23,7 +18,3 @@ Keynote Address
 
 <strong>Presentation:</strong>
 <a href="http://code4lib.org/files/hammer.pdf" target="_blank">Slides in PDF</a>
-
-
-
-

--- a/_posts/2009-05-14-a-new-platform-for-open-data-introducing-biblios-net-web-services.md
+++ b/_posts/2009-05-14-a-new-platform-for-open-data-introducing-biblios-net-web-services.md
@@ -19,13 +19,5 @@ permalink: /conference/2009/ferraro/
 ‡biblios.net is a new Software-as-a-Service offering based on the open-source ‡biblios metadata editor. ‡biblios.net provides free access to the world's largest database of openly-licensed library records--available under the Open Data Commons license and accessible via ‡biblios.net_Web_Services (BWS). BWS is a simple set of APIs that enable applications to interact with the database. This talk introduces BWS and provides examples of how it can be used by libraries/museums/archives as a platform for storing Openly Licensed Data.
 
 <p>&nbsp;</p>
-<strong>QuickTime Video:</strong>
-
-<a href="http://dl.lib.brown.edu/code4lib/ferraro.html" target="_blank">
-<img src="http://dl.lib.brown.edu/code4lib//15_ferraro.jpg" border="0" width="320" height="213"></a>
-
-<p>&nbsp;</p>
 
 <a href="http://www.archive.org/details/Code4lib2009ANewPlatformForOpenData-Introducingbiblios.netWeb">Video on Internet Archive</a>
-
-

--- a/_posts/2009-05-14-complete-faceting.md
+++ b/_posts/2009-05-14-complete-faceting.md
@@ -19,11 +19,6 @@ permalink: /conference/2009/eskildsen/
 We wanted search result faceting at our library. Just the basics with tags for material type, author and such. We found a suitable hammer and now have distributed faceting for 100 million documents with 10 times that number of unique tags. All in sync with Lucene indexes. We had to cheat a bit, but you don't see that when we wave our hands. We'll talk about why brute force and cheating is fine.
 
 <p>&nbsp;</p>
-<strong>QuickTime Video:</strong>
-<a href="http://dl.lib.brown.edu/code4lib/eskildsen.html" target="_blank">
-<img src="http://dl.lib.brown.edu/code4lib//18_eskildsen.jpg" border="0" width="320" height="213"></a>
-
-<p>&nbsp;</p>
 
 <a href="http://www.archive.org/details/Code4lib2009CompleteFaceting">Video on Internet Archive</a>
 

--- a/_posts/2009-05-14-extending-biblios-the-open-source-web-based-metadata-editor.md
+++ b/_posts/2009-05-14-extending-biblios-the-open-source-web-based-metadata-editor.md
@@ -16,10 +16,6 @@ permalink: /conference/2009/catalfo/
 <strong>Chris Catalfo</strong>, LibraryThing
 
 This talk will detail how to extend biblios, the open source web based metadata editor. It will show how to implement two possible enhancements to biblios: 1) develop a network storage folder which uses CouchDB as its backend and 2) develop an editor which supports editing Dublin Core records. The goal of this talk is to empower other developers to extend and improve biblios.
-<p>&nbsp;</p>
-<strong>QuickTime Video:</strong>
-<a href="http://dl.lib.brown.edu/code4lib/catalfo.html" target="_blank">
-<img src="http://dl.lib.brown.edu/code4lib//16_catalfo.jpg" border="0" width="320" height="213"></a>
 
 <p>&nbsp;</p>
 

--- a/_posts/2009-05-14-freebasing-for-fun-and-enhancement.md
+++ b/_posts/2009-05-14-freebasing-for-fun-and-enhancement.md
@@ -16,10 +16,6 @@ permalink: /conference/2009/hannan/
 ---
 <strong>Sean Hannan</strong>, Johns Hopkins University
 Freebase is a vast, query-able resource for hierarchical factual information. Through APIs, we can use this data and data relationships to enhance library services. Want to feature items in your catalog by local authors? Don't waste time hand-selecting, just pull dynamically from Freebase and your local collections. This presentation will cover how to get information out of Freebase via APIs, an introduction to MQL, and examples of integration with existing library services.
-<p>&nbsp;</p>
-<strong>QuickTime Video:</strong>
-<a href="http://dl.lib.brown.edu/code4lib/hannan.html" target="_blank">
-<img src="http://dl.lib.brown.edu/code4lib//22_hannan.jpg" border="0" width="320" height="213"></a>
 
 <p>&nbsp;</p>
 

--- a/_posts/2009-05-14-freecite-an-open-source-free-text-citation-parser.md
+++ b/_posts/2009-05-14-freecite-an-open-source-free-text-citation-parser.md
@@ -16,10 +16,6 @@ permalink: /conference/2009/shoemaker/
 <strong>Chris Shoemaker</strong>, Public Display
 
 FreeCite is an open-source Ruby On Rails application that parses document citations into OpenURL-style fielded data. You can use it either as a web application or through a RESTful Web API. We will explain some difficulties we encountered in developing FreeCite, describe the current architecture, discuss some of the enhancements we would like to see and explain how you can run your own server and/or improve the FreeCite software.
-<p>&nbsp;</p>
-<strong>QuickTime Video:</strong>
-<a href="http://dl.lib.brown.edu/code4lib/shoemaker.html" target="_blank">
-<img src="http://dl.lib.brown.edu/code4lib//20_shoemaker.jpg" border="0" width="320" height="213"></a>
 
 <p>&nbsp;</p>
 

--- a/_posts/2009-05-14-great-facets-like-your-relevance-but-can-i-have-links-to-amazon-and-google-book-search.md
+++ b/_posts/2009-05-14-great-facets-like-your-relevance-but-can-i-have-links-to-amazon-and-google-book-search.md
@@ -17,10 +17,6 @@ permalink: /conference/2009/wallis/
 <strong>Richard Wallis</strong>, Talis
 
 Solr enabled great innovation and prompted even more. But they are still just OPACs. Users want much more than a library catalogue alone can provide. This presentation shares some of the experience, code, and techniques used to embed a multiplicity of extension points in to an OPAC interface in a consistent way that can be built upon by others. From author videos to LibraryThing Common Knowledge by way of an audio page reader and beyond.
-<p>&nbsp;</p>
-<strong>QuickTime Video:</strong>
-<a href="http://dl.lib.brown.edu/code4lib/wallis.html" target="_blank">
-<img src="http://dl.lib.brown.edu/code4lib//21_wallis.jpg" border="0" width="320" height="213"></a>
 
 <p>&nbsp;</p>
 
@@ -30,4 +26,3 @@ Solr enabled great innovation and prompted even more. But they are still just OP
 
 <strong>Presentation:</strong>
 <a href="http://www.slideshare.net/rjw/squeezing-more-from-the-opac" target="_blank">Slides on Slideshare</a>
-

--- a/_posts/2009-05-14-the-rising-sun-making-the-most-of-solr-power.md
+++ b/_posts/2009-05-14-the-rising-sun-making-the-most-of-solr-power.md
@@ -1,11 +1,5 @@
 ---
-excerpt: "<strong>Erik Hatcher</strong>, Lucid Imagination\r\n\r\nY'all have been
-  using Solr for a good couple of years now. It rocks - we know that. But there is
-  always room for improvement. Rapid fire, Erik will go through a number of ways to
-  improve existing Solr usage in performance, relevancy, and user interface.\r\n<p>&nbsp;</p>\r\n<strong>QuickTime
-  Video:</strong>\r\n<a href=\"http://dl.lib.brown.edu/code4lib/hatcher.html\" target=\"_blank\">\r\n<img
-  src=\"http://dl.lib.brown.edu/code4lib//19_hatcher.jpg\" border=\"0\" width=\"320\"
-  height=\"213\"></a>\r\n\r\n<p>&nbsp;</p>"
+excerpt: "<strong>Erik Hatcher</strong>, Lucid Imagination\r\n\r\nY'all have been using Solr for a good couple of years now. It rocks - we know that. But there is always room for improvement. Rapid fire, Erik will go through a number of ways to improve existing Solr usage in performance, relevancy, and user interface."
 categories:
 - conferences
 - code4lib 2009
@@ -17,10 +11,6 @@ permalink: /conference/2009/hatcher/
 <strong>Erik Hatcher</strong>, Lucid Imagination
 
 Y'all have been using Solr for a good couple of years now. It rocks - we know that. But there is always room for improvement. Rapid fire, Erik will go through a number of ways to improve existing Solr usage in performance, relevancy, and user interface.
-<p>&nbsp;</p>
-<strong>QuickTime Video:</strong>
-<a href="http://dl.lib.brown.edu/code4lib/hatcher.html" target="_blank">
-<img src="http://dl.lib.brown.edu/code4lib//19_hatcher.jpg" border="0" width="320" height="213"></a>
 
 <p>&nbsp;</p>
 

--- a/_posts/2009-05-14-what-we-talk-about-when-we-talk-about-frbr.md
+++ b/_posts/2009-05-14-what-we-talk-about-when-we-talk-about-frbr.md
@@ -18,11 +18,6 @@ permalink: /conference/2009/schneider/
 <strong>Jodi Schneider</strong>, Appalachian State University; <strong>William Denton</strong>, York University
 
 When vendors talk about FRBRization they usually mean grouping manifestations into works. When we talk about FRBR, we mean something far richer and rewarding. What FRBRization algorithms are available and in use now, how well do they work, and how do they present the relationships? We'll look at the LC FRBR Display Tool, OCLC's work-set algorithm, LibraryThing's user-contributed groupings, and VTLS's system. We'll discuss their benefits, flaws, and what we need for the future.
-<p>&nbsp;</p>
-
-<strong>QuickTime Video:</strong>
-<a href="http://dl.lib.brown.edu/code4lib/schneider.html" target="_blank">
-<img src="http://dl.lib.brown.edu/code4lib//17_schneider.jpg" border="0" width="320" height="213"></a>
 
 <p>&nbsp;</p>
 

--- a/_posts/2009-05-15-if-you-love-something-set-it-free.md
+++ b/_posts/2009-05-15-if-you-love-something-set-it-free.md
@@ -11,11 +11,6 @@ permalink: /conference/2009/davis/
 Keynote Address
 
 <p>&nbsp;</p>
-<strong>QuickTime Video:</strong>
-<a href="http://dl.lib.brown.edu/code4lib/davis.html" target="_blank">
-<img src="http://dl.lib.brown.edu/code4lib//24_davis.jpg" border="0" width="320" height="213"></a>
-
-<p>&nbsp;</p>
 
 <a href="http://www.archive.org/details/Code4lib2009KeynoteAddressIanDavis">Video on Internet Archive</a>
 
@@ -23,7 +18,3 @@ Keynote Address
 
 <strong>Presentation:</strong>
 <a href="http://www.slideshare.net/iandavis/code4lib2009-keynote-1073812" target="_blank">Slides on Slideshare</a>
-
-
-
-

--- a/_posts/2009-05-15-the-open-platform-strategy-what-it-means-for-library-developers.md
+++ b/_posts/2009-05-15-the-open-platform-strategy-what-it-means-for-library-developers.md
@@ -17,10 +17,6 @@ permalink: /conference/2009/corrado/
 <strong>Edward M. Corrado</strong>, Binghamton University
 
 Ex Libris has announced an Open Platform Strategy. As part of this approach they will supply well-documented “Open-APIs” and Web services. They have also created EL Commons, a collaborative Web-based platform that includes a Developer Zone and a code-sharing platform for customers. OCLC also has an Open-API approach with the WorldCat Grid. This presentation will investigate what this Open-API strategy means for customers and why (or why not) libraries should support this “open”-proprietary strategy.
-<p>&nbsp;</p>
-<strong>QuickTime Video:</strong>
-<a href="http://dl.lib.brown.edu/code4lib/corrado.html" target="_blank">
-<img src="http://dl.lib.brown.edu/code4lib//25_corrado.jpg" border="0" width="320" height="213"></a>
 
 <p>&nbsp;</p>
 

--- a/_posts/2009-05-15-visualizing-media-archives-a-case-study.md
+++ b/_posts/2009-05-15-visualizing-media-archives-a-case-study.md
@@ -17,10 +17,6 @@ permalink: /conference/2009/beer/
 <strong>Chris Beer</strong>, WGBH Interactive; <strong>Courtney Michael</strong>, WGBH Media Library and Archives
 
 A scholar walks into your archive and asks “what do you have for me?” You point to your finding aids and set them a-slogging. What if they could orient themselves to, and interact with, the collection dynamically online? What if they could see the connections between collections, series, even items? We will present our latest approach to showcasing the breadth and depth of media collections using rich cataloging and data visualization techniques.
-<p>&nbsp;</p>
-<strong>QuickTime Video:</strong>
-<a href="http://dl.lib.brown.edu/code4lib/beer.html" target="_blank">
-<img src="http://dl.lib.brown.edu/code4lib//26_beer.jpg" border="0" width="320" height="213"></a>
 
 <p>&nbsp;</p>
 


### PR DESCRIPTION
Removes links to broken Quicktime videos from the 2009 conference. While the URLs can be updated to resolve correctly, the videos no longer seem to work on the Brown website, e.g.: 

https://library.brown.edu/code4lib/lightning_day1.html

The pages still have links to versions hosted on the Internet Archive though.

Resolves #14 