### PR TITLE
Update header.html

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -30,7 +30,7 @@
           <a class="page-link" href="http://jobs.code4lib.org">Jobs</a>
           <a class="page-link" href="https://journal.code4lib.org">Journal</a>
           <a class="page-link" href="/local/">Local</a>
-          <a class="page-link" href="https://lists.clir.org/cgi-bin/wa?A0=CODE4LIB">Mailing List</a>
+          <a class="page-link" href="https://wiki.code4lib.org/MailingList">Mailing List</a>
           <a class="page-link" href="http://planet.code4lib.org">Planet</a>
           <a class="page-link" href="https://wiki.code4lib.org">Wiki</a>
 


### PR DESCRIPTION
This edit points reader to a wiki page describing the mailing list, instead of pointing to the LISTSERV home page. This way the mailing list gets more context.