### PR TITLE
Point IRC information to libera.chat instead of freenode

### DIFF
--- a/_pages/chat.md
+++ b/_pages/chat.md
@@ -11,8 +11,9 @@ There are code4lib chat rooms for folks who are interested in the convergence of
 
 <h2 id="irc">IRC</h2>
 <ul>
-<li><strong>Server:</strong> chat.freenode.net</li>
-<li><strong>Channels:</strong> <a href="irc://irc.freenode.net/code4lib">#code4lib</a> (alternate port for if port 6667 is blocked by your firewall: <a href="irc://irc.freenode.net:8000/code4lib">8000</a>)</li>
+<li><strong>Network:</strong <a href="https://libera.chat">Libera.chat</a></li>
+<li><strong>Server:</strong> irc.libera.chat</li>
+<li><strong>Channels:</strong> <a href="ircs://irc.libera.chat/code4lib">#code4lib</a> (alternate port for if port 6697 is blocked by your firewall: <a href="irc://irc.libera.chat:8000/code4lib">8000</a>)</li>
 <li><a href="http://code4lib.org/irc/faq">FAQ</a></li>
 <li><a href="http://wiki.code4lib.org/index.php/Zoia_or_the_Code4Lib_IRC_bot">Zoia IRC Bot</a></li>
 </ul>
@@ -21,12 +22,9 @@ Stop by and say hello.
 
 If you don't already have an IRC client, there are several options available at no cost.
 <ul>
-<li>Easiest: connect through the web at 
-<a href="http://webchat.freenode.net/">http://webchat.freenode.net/</a> Nickname: pick a name, Channels: #code4lib
 
-
-Also useful if you can't install a client, or if IRC traffic is blocked on your network, 
-</li> 
+If you can't install a client, or if IRC traffic is blocked on your network,
+</li>
 <li><a href="http://irccloud.com/">IRCCloud</a> is a <abbr title="software as a service">SaaS</abbr> IRC client that runs in most modern browsers.</li>
 <li>
   If you have <a href="http://pidgin.im/">Pidgin</a> installed, it provides IRC access.
@@ -37,9 +35,9 @@ Also useful if you can't install a client, or if IRC traffic is blocked on your 
 
 If you're unfamiliar with IRC, this <a href="http://www.irchelp.org/irchelp/new2irc.html#detail">brief introduction</a> should help get you up to speed. You might also want to check out <a href="http://code4lib.org/irc/faq">this FAQ</a>, which answers some common questions about the #code4lib channel specifically.
 
-You can register your nickname with Freenode's NickServ service to keep using the same nickname. After you are registered, identify to NickServ. More details and the commands to use are listed at Freenode's FAQ: <a href="http://freenode.net/faq.shtml#nicksetup">http://freenode.net/faq.shtml#nicksetup</a>. This will allow you more  privileges, such as sending private messages to other registered users.
+You can register your nickname with Libera's NickServ service to keep using the same nickname. After you are registered, identify to NickServ. More details and the commands to use are listed at <a href="https://libera.chat/guides/registration">Libera's FAQ</a>. This will allow you more privileges, such as sending private messages to other registered users.
 
-To perform some of the commands listed in the <a href="http://code4lib.org/irc/faq">FAQ</a> you need to register and identify with Zoia. This is similar to but separate from the registration with Freenode's NickServ. Remember to identify each time you log in. Register by <code>/msg zoia register nickname password</code>. Once registered, Identify by <code>/msg zoia identify nickname password</code>.  To change your password: <code>/msg zoia set password oldpassword newpassword</code>.
+To perform some of the commands listed in the <a href="http://code4lib.org/irc/faq">FAQ</a> you need to register and identify with Zoia. This is similar to but separate from the registration with Libera's NickServ. Remember to identify each time you log in. Register by <code>/msg zoia register nickname password</code>. Once registered, Identify by <code>/msg zoia identify nickname password</code>.  To change your password: <code>/msg zoia set password oldpassword newpassword</code>.
 
 Finally, #code4lib is a social and technical discussion channel. Keep in mind that the discussion isn't limited to library technologies, and can cover a lot of ground.
 
@@ -55,3 +53,6 @@ Joining a Slack team requires an invitation, but anyone can generate an automati
 
 A tutorial can be found at <a href="https://code4lib.slack.com/getting-started">https://code4lib.slack.com/getting-started</a>.  Slack has clients for Mac, PC, Linux, and mobile devices, and may be used via any web browser.
 
+<h2 id="other">Other platforms</h2>
+
+In addition to IRC and Slack, there is also a Code4lib Discord server and a <a href="https://code4lib.zulipchat.com/">Zulip team</a>.

--- a/_posts/2006-03-14-code4lib-irc-channel-faq.md
+++ b/_posts/2006-03-14-code4lib-irc-channel-faq.md
@@ -23,13 +23,13 @@ Not publicly, no.
 
 ### Who can I ask for help?
 
-#code4lib has a designated group of "helpers," who can answer questions or provide support. The channel's official group contacts to Freenode are Mark Matienzo (`anarchivist`), Becky Yoose (`yo_bj`), and Ross Singer (`rsinger`); all three of them have channel operator privileges.
+#code4lib has a designated group of "helpers," who can answer questions or provide support. The channel's official group contacts to Libera are Mark Matienzo (`anarchivist`), Becky Yoose (`yo_bj`), and Ross Singer (`rsinger`); all three of them have channel operator privileges.
 
 ### What about ~~panizzi~~ zoia?
 
 Zoia is a [supybot](https://github.com/Supybot/Supybot) who hangs out in #code4lib. To get a list of commands it understands, type `@list` (the "@" symbol tells zoia you're talking to it). Here's a quick list of the more common commands:
 
-#### `@help`<
+#### `@help`
 
 Find out how to use a particular command. The correct syntax is (usually) `@help` followed by the command name, e.g. `@help karma`. You can also just ask the other people on the channel how to do something.
 
@@ -78,7 +78,7 @@ Information technology, software development, librarianship, cultural heritage, 
 3. Be sensitive of the fact that cultures, opinions and ideas of what is funny or appropriate are different, and that text is a very poor medium for conveying humor.
 4. Because this is the case, and people will be people, be quick to forgive and slow to take offense.
 
-Aside from that, it's a bit of a free-for-all. Basically, use common sense, be respectful of others, and don't do anything that will get everyone kicked off of Freenode.
+Aside from that, it's a bit of a free-for-all. Basically, use common sense, be respectful of others, and don't do anything that will get everyone kicked off of Libera.
 
 ### What does "++" mean?
 


### PR DESCRIPTION
As some of you may be aware, the former head of Freenode ltd., the holding company for the Freenode IRC network, sold the organization to a third party under terms that hadn't been disclosed to staff. Most Freenode staff (e.g. [0], [1]) have resigned their posts and are urging communities that use Freenode for IRC to abandon the network. This has become even more urgent given recently reported routine abuses of power [2] and a rollback on Freenode policy banning hate speech. [3]

Former Freenode staffers have founded a new IRC network, Libera.chat. A handful of us (thanks, jeff) have started to set up a new #code4lib channel there (`ircs://irc.libera.chat/code4lib`), although there's work to do to relocate zoia, the Code4lib IRC bot, and update the web pages (this PR). 

As always, this is a reminder that we don't have good processes or policies for dealing with these sorts of changes in the Code4lib community. This was not a unilateral decision, but one informed by a number of other folks in IRC.

[0]: https://www.kline.sh/
[1]: https://fuchsnet.ch/freenode-resign-letter.txt
[2]: https://www.devever.net/~hl/freenode_abuse
[3]: https://github.com/freenode/web-7.0/pull/513/files 